### PR TITLE
QCM 1

### DIFF
--- a/Exercices/QCM/S1/qcm-1.rst
+++ b/Exercices/QCM/S1/qcm-1.rst
@@ -282,7 +282,7 @@ Parmi les groupes d'affirmations ci-dessous, un seul ne contient que des affirma
 
   .. class:: comment
 
-     Les trois affirmations sont fausses.
+     Les trois affirmations sont fausses. ``argc`` sera toujours initialisé à un vu que le nom du programme est toujours passé en argument. Le premier élément du tableau ``argv[]``, ``argv[0]``, est le nom du programme qui est exécuté. Enfin, la fonction ``atoi`` permet de convertir une chaîne de caractères en l'entier équivalent.
 
 -  
   - Lors de l'exécution de la fonction ``main``, ``argc`` est le nombre maximum d'arguments que l'on peut lui passer.
@@ -291,7 +291,7 @@ Parmi les groupes d'affirmations ci-dessous, un seul ne contient que des affirma
 
   .. class:: comment
 
-     Les deux premières affirmations sont fausses.
+     Les deux premières affirmations sont fausses. ``argc`` contient le nombre d'arguments passés effectivement au programme. Le premier élément du tableau ``argv[]``, ``argv[0]``, est le nom du programme qui est exécuté.
 
 -  
   - Lors de l'exécution de la fonction ``main``, le tableau ``argv[]`` contient dans ```argv[0]`` le premier argument, dans ``argv[1]`` le second argument, etc.


### PR DESCRIPTION
Correction de l'orthographe et suggestions concernant les commentaires après erreur, le tout divisé en trois commits :
- Fix typo : Reprend l'ensemble des corrections orthographiques + un lien vers la bibliographie à vérifier (je n'ai pas su vérifier moi-même conformément à l'issue #4 )
- Fix commentaire : Reprend un commentaire en cas d'erreur qui ne correspondait pas tout à fait à la mauvaise réponse
- Comments suggestion : Reprend une liste suggérée de commentaires d'erreur (à vérifier, car peut-être trop précis)
