### PR TITLE
Remove duplicate table and fix typos

### DIFF
--- a/Exercices/QCM/S2/qcm-2.rst
+++ b/Exercices/QCM/S2/qcm-2.rst
@@ -491,7 +491,7 @@ Une seule des fonctions ci-dessous retourne correctement le nombre d'occurrences
    int count1(char *s, char c) {
      int i=0;
      int count=0;
-     while(*s!=`\0`) {
+     while(*s!='\0') {
        if(*(s+i)==c) {
           count++;
        }

--- a/Theorie/intro.rst
+++ b/Theorie/intro.rst
@@ -218,32 +218,6 @@ Ce programme utilise le fichier spécial ``/dev/null``. Celui-ci est en pratique
 
 Une description complète de `bash(1)`_ sort du cadre de ce cours. De nombreuses références à ce sujet sont disponibles [Cooper2011]_.
 
-
-
-
-.. topic:: Pages de manuel
-
-  Les systèmes d'exploitation de la famille Unix contiennent un grand nombre de librairies, d'appels systèmes et d'utilitaires. Toutes ces fonctions et tous ces programmes sont documentés dans des pages de manuel qui sont accessibles via la commande ``man``. Les pages de manuel sont organisées en 8 sections.
-
-   - Section 1: Utilitaires disponibles pour tous les utilisateurs
-   - Section 2: Appels systèmes en C
-   - Section 3: Fonctions de la librairie
-   - Section 4: Fichiers spéciaux
-   - Section 5: Formats de fichiers et conventions pour certains types de fichiers
-   - Section 6: Jeux
-   - Section 7: Utilitaires de manipulation de fichiers textes
-   - Section 8: Commandes et procédure de gestion du système
-
-  Dans le cadre de ce cours, nous aborderons principalement les fonctionnalités décrites dans les trois premières sections des pages de manuel. L'accès à une page de manuel se fait via la commande ``man`` avec comme argument le nom de la commande concernée. Vous pouvez par exemple obtenir la page de manuel de ``gcc`` en tapant ``man gcc``. ``man`` supporte plusieurs paramètres qui sont décrits dans sa page de manuel accessible via ``man man``. Dans certains cas, il est nécessaire de spécifier la section du manuel demandée. C'est le cas par exemple pour ``printf`` qui existe comme utilitaire (section 1) et comme fonction de la librairie (section 3 - accessible via ``man 3 printf``).
-
-  Outre ces pages de manuel locales, il existe également de nombreux sites web où l'on peut accéder aux pages de manuels de différentes versions de Unix dont notamment :
-
-   - les pages de manuel de `Debian GNU/Linux <http://manpages.debian.net/>`_
-   - les pages de manuel de `FreeBSD <http://www.freebsd.org/cgi/man.cgi>`_
-   - les pages de manuel de `MacOS <http://developer.apple.com/documentation/Darwin/Reference/ManPages/index.html>`_
-
-  Dans la version online de ces notes, toutes les références vers un programme Unix, un appel système ou une fonction de la librairie pointent vers la page de manuel Linux correspondante.
-
 .. rubric:: Footnotes
 
 .. [#fbitreseau] Dans certaines applications, par exemple dans les réseaux informatiques, il peut être utile d'accéder à la valeur d'un bit particulier qui joue par exemple le rôle d'un drapeau. Celui-ci se trouve cependant généralement à l'intérieur d'une structure de données comprenant un ensemble de bits.
@@ -253,4 +227,3 @@ Une description complète de `bash(1)`_ sort du cadre de ce cours. De nombreuses
 .. [#ftermine] Certains processus sont lancés automatiquement au démarrage du système et ne se terminent qu'à son arrêt. Ces processus sont souvent appelés des `daemons`. Il peut s'agir de services qui fonctionnent en permanence sur la machine, comme par exemple un serveur web ou un `daemon` d'authentification.
 
 .. [#fexecbit] Sous Unix et contrairement à d'autres systèmes d'exploitation, le suffixe d'un nom de fichier ne joue pas de rôle particulier pour indiquer si un fichier contient un programme exécutable ou non. Comme nous le verrons ultérieurement, le système de fichiers Unix contient des bits de permission qui indiquent notamment si un fichier est exécutable ou non.
-

--- a/Theorie/intro.rst
+++ b/Theorie/intro.rst
@@ -149,7 +149,7 @@ Les shells Unix supportent un second mécanisme qui est encore plus intéressant
 .. literalinclude:: src/exemple3.out
         :language: console
 
-Le premier exemple est d'utiliser `echo(1)`_ pour générer du texte et le passer directement à `wc(1)`_ qui compte le nombre de caractères. Le deuxième exemple utilise `cat(1)`_ pour afficher sur le sortie standard le contenu d'un fichier. Cette sortie est reliée à `sort(1)`_ qui trie le texte reçu sur son entrée standard en ordre alphabétique croissant. Cette sortie en ordre alphabétique est reliée à `uniq(1)`_ qui la filtre pour en retirer les lignes dupliquées.
+Le premier exemple est d'utiliser `echo(1)`_ pour générer du texte et le passer directement à `wc(1)`_ qui compte le nombre de caractères. Le deuxième exemple utilise `cat(1)`_ pour afficher sur la sortie standard le contenu d'un fichier. Cette sortie est reliée à `sort(1)`_ qui trie le texte reçu sur son entrée standard en ordre alphabétique croissant. Cette sortie en ordre alphabétique est reliée à `uniq(1)`_ qui la filtre pour en retirer les lignes dupliquées.
 
 
 Tout shell Unix peut également s'utiliser comme un interpréteur de commande qui permet d'interpréter des scripts. Un système Unix peut exécuter deux types de programmes :
@@ -157,7 +157,7 @@ Tout shell Unix peut également s'utiliser comme un interpréteur de commande qu
  - des programmes exécutables en langage machine. C'est le cas de la plupart des utilitaires dont nous avons parlé jusqu'ici.
  - des programmes écrits dans un langage interprété. C'est le cas des programmes écrits pour le shell, mais également pour d'autres langages interprétés comme python_ ou perl_.
 
-Lors de l'exécution d'un programme, le système d'exploitation reconnaît [#fexecbit]_ si il s'agit d'un programme directement exécutable ou d'un programme interprété en analysant les premiers octets du fichier. Par convention, sous Unix, les deux premiers caractères d'un programme écrit dans un langage qui doit être interprété sont ``#!``. Ils sont suivis par le nom complet de l'interpréteur qui doit être utilisé pour interpréter programme.
+Lors de l'exécution d'un programme, le système d'exploitation reconnaît [#fexecbit]_ si il s'agit d'un programme directement exécutable ou d'un programme interprété en analysant les premiers octets du fichier. Par convention, sous Unix, les deux premiers caractères d'un programme écrit dans un langage qui doit être interprété sont ``#!``. Ils sont suivis par le nom complet de l'interpréteur qui doit être utilisé pour interpréter le programme.
 
 Le programme `bash(1)`_ le plus simple est le suivant :
 


### PR DESCRIPTION
Deux petites fautes de frappes et suppression du tableau en double 'Page de Manuel' présent actuellement aux pages 8 et 13. Il me semble mieux de le laisser à la page 13 puisque les exemples utilisés sont ``gcc`` et ``printf`` (pas encore introduits à la page 8).