### PR TITLE
Eclaircissement des permissions de CHMOD

### DIFF
--- a/Theorie/Fichiers/fichiers.rst
+++ b/Theorie/Fichiers/fichiers.rst
@@ -187,12 +187,12 @@ Les valeurs de ces bits sont représentés pas les symboles ``rwx`` dans l'outpu
   - ``S_IRUSR (00400)`` : permission de lecture par le propriétaire
   - ``S_IWUSR (00200)`` : permission d'écriture par le propriétaire
   - ``S_IXUSR (00100)`` : permission d'exécution par le propriétaire
-  - ``S_IRGRP (00040)`` : permission de lecture par le groupe
-  - ``S_IWGRP (00020)`` : permission d'écriture par le groupe
-  - ``S_IXGRP (00010)`` : permission d'exécution par le groupe
-  - ``S_IROTH (00004)`` : permission de lecture par n'importe quel utilisateur
-  - ``S_IWOTH (00002)`` : permission d'écriture par n'importe quel utilisateur
-  - ``S_IXOTH (00001)`` : permission d'exécution par n'importe quel utilisateur
+  - ``S_IRGRP (00040)`` : permission de lecture par le groupe hormis le propriétaire
+  - ``S_IWGRP (00020)`` : permission d'écriture par le groupe hormis le propriétaire
+  - ``S_IXGRP (00010)`` : permission d'exécution par le groupe hormis le propriétaire
+  - ``S_IROTH (00004)`` : permission de lecture par tout utilisateur hormis le propriétaire et son groupe
+  - ``S_IWOTH (00002)`` : permission d'écriture par tout utilisateur hormis le propriétaire et son groupe
+  - ``S_IXOTH (00001)`` : permission d'exécution par tout utilisateur hormis le propriétaire et son groupe
 
   .. code-block:: c
 


### PR DESCRIPTION
Les définitions des permissions manipulées par l'appel système chmod(2) ne nous semblaient pas assez claires. Elles pouvaient porter à confusion car nous pourrions interpréter ces permissions comme un système d' "héritage" (n'importe quel utilisateur pourrait signifier tout utilisateur, y compris le propriétaire et son groupe).
- Modification apportée par François Michel et Robin Descamps