### PR TITLE
Mise à jour question 2 semaine 12

### DIFF
--- a/Exercices/Programmes/prog-12.rst
+++ b/Exercices/Programmes/prog-12.rst
@@ -10,7 +10,7 @@ Exercices
 #. Un processus père ouvre un segment de mémoire partagée avec l'appel système ``shmget(key, 4096, IPC_CREAT | S_IRUSR | S_IWUSR )``. Un de ses processus fils peut-il exécuter ``shmget(key, 4096, S_IRUSR  )`` ? Si oui, ce processus peut-il ensuite attacher cette page en utilisant :
 
  - ``shmat(shm_id, NULL, SHM_RDONLY)``
- - ``shmat(shm_id, NULL, SHM_RDONLY)``
+ - ``shmat(shm_id, NULL, SHM_EXEC)``
 
 #. Lorsque l'on utilise l'appel système `shmat(2)`_ avec ``NULL`` come deuxième argument, le système d'exploitation choisit l'adresse à laquelle le segment de mémoire va être attaché. Cela pose des difficultés si l'on veut stocker des pointeurs en mémoire partagée. Un étudiant propose de d'abord allouer la zone mémoire avec `malloc(3)`_ et d'ensuite attacher le segment de mémoire à cet endroit. Il a réalisé un test avec un processus père et son fils et les deux segments de mémoire partagée se retrouvent à la même adresse. Il en conclut que cela permet de résoudre le problème. Qu'en pensez-vous ?
 


### PR DESCRIPTION
La question demandait ce qui se passait à chaque fois avec ``shmat(shm_id, NULL, SHM_RDONLY)``. Peut-être ça pourrait-être utile de remplacer l'un des deux par ``shmat(shm_id, NULL, SHM_EXEC)`` (à moins qu'on s'intéressait à un double appel?)