### PR TITLE
Correction de l'exemple de manipulation de la pile

### DIFF
--- a/Theorie/Assembleur/memory.rst
+++ b/Theorie/Assembleur/memory.rst
@@ -537,7 +537,7 @@ Pour bien comprendre le fonctionnement de la pile, il est utile de considérer u
    push %ebx ; %esp contient 0x04 et M[0x04]=0xFF
    pop %eax  ; %esp contient 0x08 et %eax 0xFF
    pop %ebx  ; %esp contient 0x0C et %ebx 0x02
-   pop %eax  ; %esp contient 0x10 et %eax 0x04
+   pop %eax  ; %esp contient 0x10 et %eax 0x00
 
 
 Les fonctions et procédures


### PR DESCRIPTION
A moins d'avoir mal compris, je pense qu'il y a une erreur dans l'exemple de la manipulation de la pile. Lors du dernier pop, la valeur que prend %eax est 0x00 et non 0x04, car %esp contenait 0x0C avant cette instruction pop.